### PR TITLE
Run all which commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function setAvailableApps(cb) {
 	});
 
 	// `which` all commands and expect stdout to return a positive
-	var whichCmd = 'which -a ' + names.join(' && which -a ');
+	var whichCmd = 'which -a ' + names.join('; which -a ');
 
 	childProcess.exec(whichCmd, function (err, stdout) {
 		if (!stdout) {


### PR DESCRIPTION
This patch ensures that apps get their availability detected by letting their `which` commands run even if a previous `which` command returns nonzero.